### PR TITLE
画面展開時にキーボードでボタン等が隠れてしまう症状を回避。 EditTextへの自動フォーカスインを別のビューに移すことで対処。

### DIFF
--- a/app/src/main/res/layout/input_address.xml
+++ b/app/src/main/res/layout/input_address.xml
@@ -18,6 +18,8 @@
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="アドレスを入力してください"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:id="@+id/lblInputAddress" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/input_passcode.xml
+++ b/app/src/main/res/layout/input_passcode.xml
@@ -22,6 +22,8 @@ android:layout_height="match_parent">
             android:text="パスコードを入力してください"
             android:id="@+id/lblInputAddress"
             android:layout_gravity="center_vertical"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:layout_weight="0.2" />
 
     </LinearLayout>


### PR DESCRIPTION
画面展開時にキーボードでボタン等が隠れてしまう症状を回避。
EditTextへの自動フォーカスインを別のビューに移すことで対処。
